### PR TITLE
Cached store

### DIFF
--- a/cached/cached.go
+++ b/cached/cached.go
@@ -1,0 +1,85 @@
+package cached
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/uncloud-registry/swarm-driver/lookuper"
+	"github.com/uncloud-registry/swarm-driver/publisher"
+)
+
+type cachedLookuperPublisher struct {
+	lookuper.Lookuper
+	publisher.Publisher
+
+	timeout time.Duration
+	cached  *lru.Cache[string, cachedResult]
+	mtx     sync.RWMutex
+}
+
+type cachedResult struct {
+	ref swarm.Address
+	err error
+	ts  int64
+}
+
+func New(lk lookuper.Lookuper, pb publisher.Publisher, timeout time.Duration) (*cachedLookuperPublisher, error) {
+	cache, err := lru.New[string, cachedResult](10000)
+	if err != nil {
+		return nil, err
+	}
+	return &cachedLookuperPublisher{
+		Lookuper:  lk,
+		Publisher: pb,
+		timeout:   timeout,
+		cached:    cache,
+	}, nil
+}
+
+func (c *cachedLookuperPublisher) Get(ctx context.Context, id string, version int64) (swarm.Address, error) {
+	c.mtx.RLock()
+	cRef, found := c.cached.Get(id)
+	c.mtx.RUnlock()
+	if found {
+		if time.Since(time.Unix(cRef.ts, 0)) > 3*time.Second {
+			go func() {
+				ref, err := c.get(context.Background(), id, version)
+				if err == nil {
+					c.mtx.Lock()
+					_ = c.cached.Add(id, cachedResult{ref: ref, err: err, ts: time.Now().Unix()})
+					c.mtx.Unlock()
+				}
+			}()
+		}
+		res := cRef
+		// log.Debugf("returning cached result id %s ref %s err %v", id, res.ref.String(), res.err)
+		return res.ref, res.err
+	}
+	ref, err := c.get(ctx, id, version)
+	c.mtx.Lock()
+	_ = c.cached.Add(id, cachedResult{ref: ref, err: err, ts: time.Now().Unix()})
+	c.mtx.Unlock()
+	// log.Debugf("adding to cache id %s ref %s err %v", id, ref.String(), err)
+	return ref, err
+}
+
+func (c *cachedLookuperPublisher) get(ctx context.Context, id string, version int64) (swarm.Address, error) {
+	cctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	return c.Lookuper.Get(cctx, id, version)
+}
+
+func (c *cachedLookuperPublisher) Put(ctx context.Context, id string, version int64, ref swarm.Address) error {
+	err := c.Publisher.Put(ctx, id, version, ref)
+	if err == nil {
+		c.mtx.Lock()
+		_ = c.cached.Add(id, cachedResult{ref: ref, ts: time.Now().Unix()})
+		c.mtx.Unlock()
+		// log.Debugf("adding to cache id %s ref %s", id, ref.String())
+	}
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ethereum/go-ethereum v1.14.3
 	github.com/ethersphere/bee/v2 v2.2.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/testcontainers/testcontainers-go v0.34.0
 )

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/holiman/uint256 v1.2.4 h1:jUc4Nk8fm9jZabQuqr2JzednajVmBpC+oiTiXZJEApU=
 github.com/holiman/uint256 v1.2.4/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=

--- a/store/cachedstore/cachedstore.go
+++ b/store/cachedstore/cachedstore.go
@@ -1,0 +1,51 @@
+package cachedstore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/ethersphere/bee/v2/pkg/swarm"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/uncloud-registry/swarm-driver/store"
+)
+
+type cachedStore struct {
+	store.PutGetter
+	cache *lru.Cache[string, swarm.Chunk]
+	mtx   sync.RWMutex
+}
+
+func New(st store.PutGetter) (*cachedStore, error) {
+	cache, err := lru.New[string, swarm.Chunk](100000)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating cache %w", err)
+	}
+	return &cachedStore{PutGetter: st, cache: cache}, nil
+}
+
+func (c *cachedStore) Get(ctx context.Context, address swarm.Address) (ch swarm.Chunk, err error) {
+	c.mtx.RLock()
+	ch, found := c.cache.Get(address.ByteString())
+	c.mtx.RUnlock()
+	if !found {
+		ch, err = c.PutGetter.Get(ctx, address)
+		if err == nil {
+			c.mtx.Lock()
+			_ = c.cache.Add(address.ByteString(), ch)
+			c.mtx.Unlock()
+			// log.Debugf("adding chunk to cache %s", ch.Address().String())
+		}
+	}
+	return
+}
+
+func (c *cachedStore) Put(ctx context.Context, ch swarm.Chunk) (err error) {
+	err = c.PutGetter.Put(ctx, ch)
+	if err == nil {
+		c.mtx.Lock()
+		_ = c.cache.Add(ch.Address().ByteString(), ch)
+		c.mtx.Unlock()
+	}
+	return err
+}


### PR DESCRIPTION
This pull request introduces a caching layer for the `swarm-driver` package to improve performance by reducing redundant lookups and storage operations.

### Caching Mechanisms:

* **`cachedLookuperPublisher` Implementation:**
  - Added a new `cachedLookuperPublisher` type that wraps the existing `Lookuper` and `Publisher` interfaces with caching capabilities using an LRU cache. (`cached/cached.go`)

* **`cachedStore` Implementation:**
  - Added a new `cachedStore` type that wraps the existing `PutGetter` interface with caching capabilities using an LRU cache. (`store/cachedstore/cachedstore.go`)
  - Implemented methods `Get` and `Put` to handle cache retrieval and updating logic. (`store/cachedstore/cachedstore.go`)